### PR TITLE
Make sure git never invokes the pager

### DIFF
--- a/lib/recap/support/capistrano_extensions.rb
+++ b/lib/recap/support/capistrano_extensions.rb
@@ -40,12 +40,12 @@ module Recap::Support::CapistranoExtensions
 
   # Run a git command in the `deploy_to` directory
   def git(command)
-    run "cd #{deploy_to} && umask 002 && sg #{application_group} -c \"git #{command}\""
+    run "cd #{deploy_to} && umask 002 && sg #{application_group} -c \"git --no-pager #{command}\""
   end
 
   # Capture the result of a git command run within the `deploy_to` directory
   def capture_git(command)
-    capture "cd #{deploy_to} && umask 002 && sg #{application_group} -c 'git #{command}'"
+    capture "cd #{deploy_to} && umask 002 && sg #{application_group} -c 'git --no-pager #{command}'"
   end
 
   def exit_code(command)


### PR DESCRIPTION
When the list of deployed tags gets long enough `git tag` sends the output to a pager which we are not expecting. This change just instructs git not to do that so things can continue on as normal.